### PR TITLE
add lane-following start/stop commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY joy_cli.py .
 RUN [ "cross-build-start" ]
 
 RUN chmod +x ./joy_cli.py
+RUN chmod +x ./run_joy_cli.sh
 
 ENTRYPOINT ./run_joy_cli.sh
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Run:
 
 The robot should move when you press <kbd>a</kbd>, <kbd>w</kbd>, <kbd>s</kbd>, or <kbd>d</kbd>. You should press <kbd>Enter</kbd> afterwards and the robot will move for half a second in the desired direction.
 
+To initiate (or stop) the lane-following demo, enter `start` (or `stop`) and press <kbd>Enter</kbd>.
+
 ## Dependencies
 
 * `rospy`

--- a/joy_cli.py
+++ b/joy_cli.py
@@ -22,9 +22,9 @@ def keyCatcher(host):
         elif input == 's':
             axes = [0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         elif input == 'd':
-            axes = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]
-        elif input == 'a':
             axes = [0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0]
+        elif input == 'a':
+            axes = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]
         elif input == 'start':
             # sends START to joystick (#7) to start lane-follow
             buttons[7] = 1

--- a/joy_cli.py
+++ b/joy_cli.py
@@ -15,15 +15,24 @@ def keyCatcher(host):
     buttons = [0] * 11
 
     while not rospy.is_shutdown():
-        direction = raw_input('Enter direction(a,w,s,d)--> ')
-        if direction == 'w':
+        input = raw_input('Enter direction(a,w,s,d) or lane-follow(start,stop)--> ')
+
+        if input == 'w':
             axes = [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-        elif direction == 's':
+        elif input == 's':
             axes = [0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-        elif direction == 'd':
-            axes = [0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0]
-        elif direction == 'a':
+        elif input == 'd':
             axes = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]
+        elif input == 'a':
+            axes = [0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0]
+        elif input == 'start':
+            # sends START to joystick (#7) to start lane-follow
+            buttons[7] = 1
+            axes = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        elif input == 'stop':
+            # sends BACK to joystick (#6) to stop lane-follow
+            buttons[6] = 1
+            axes = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         else:
             axes = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
@@ -31,6 +40,7 @@ def keyCatcher(host):
         pub.publish(msg)
         rospy.sleep(0.5)
 
+        buttons = [0] * 11
         axes = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         msg = Joy(header=None, axes=axes, buttons=buttons)
         pub.publish(msg)


### PR DESCRIPTION
Start & stop lane-following demo commands for the keyboard control when using the flag `--cli`, in particular, it's useful for Mac users.

Will need to update docker image `duckietown/rpi-duckiebot-cli` which gets called by duckietown-shell.